### PR TITLE
add unit tests for invitationservice and notificationservice

### DIFF
--- a/ItTakesAVillage.Tests/BaseEventTests.cs
+++ b/ItTakesAVillage.Tests/BaseEventTests.cs
@@ -1,0 +1,58 @@
+﻿using ItTakesAVillage.Contracts;
+using ItTakesAVillage.Models;
+using ItTakesAVillage.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ItTakesAVillage.Tests
+{
+    public class BaseEventTests
+    {
+        private readonly Mock<IRepository<DinnerInvitation>> _dinnerInvitationRepositoryMock;
+        private readonly DinnerInvitationService _sut;
+
+        public BaseEventTests()
+        {
+            _dinnerInvitationRepositoryMock = new Mock<IRepository<DinnerInvitation>>();
+
+            _sut = new DinnerInvitationService(_dinnerInvitationRepositoryMock.Object);
+        }
+        [Fact]
+        public async Task Create_InvitationInFuture_ShouldReturnTrue()
+        {
+            // Arrange
+            var futureDate = DateTime.Now.AddDays(1);
+            var dinnerInvitation = new DinnerInvitation { DateTime = futureDate };
+
+            _dinnerInvitationRepositoryMock.Setup(x => x.AddAsync(It.IsAny<DinnerInvitation>()))
+                                          .Returns(Task.CompletedTask);
+
+            // Act
+            var actual = await _sut.Create(dinnerInvitation);
+
+            // Assert
+            Assert.True(actual);
+            _dinnerInvitationRepositoryMock.Verify(x => x.AddAsync(It.IsAny<DinnerInvitation>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Create_InvitationInPast_ShouldReturnFalse()
+        {
+            // Arrange
+            var pastDate = DateTime.Now.AddDays(-1);
+            var dinnerInvitation = new DinnerInvitation { DateTime = pastDate };
+
+            // Act
+            var actual = await _sut.Create(dinnerInvitation);
+
+            // Assert
+            Assert.False(actual);
+            _dinnerInvitationRepositoryMock.Verify(x => x.AddAsync(It.IsAny<DinnerInvitation>()), Times.Never);
+        }
+    }
+}

--- a/ItTakesAVillage.Tests/NotificationTests.cs
+++ b/ItTakesAVillage.Tests/NotificationTests.cs
@@ -1,0 +1,145 @@
+﻿using ItTakesAVillage.Contracts;
+using ItTakesAVillage.Models;
+using ItTakesAVillage.Services;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ItTakesAVillage.Tests
+{
+    public class NotificationTests
+    {
+        private readonly Mock<IGroupService> _groupServiceMock;
+        private readonly Mock<IRepository<ItTakesAVillageUser>> _userRepositoryMock;
+        private readonly Mock<IRepository<Notification>> _notificationRepositoryMock;
+        private readonly NotificationService _sut;
+
+        public NotificationTests()
+        {
+            _groupServiceMock = new Mock<IGroupService>();
+            _userRepositoryMock = new Mock<IRepository<ItTakesAVillageUser>>();
+            _notificationRepositoryMock = new Mock<IRepository<Notification>>();
+
+            _sut = new NotificationService(_groupServiceMock.Object,
+                                   _userRepositoryMock.Object,
+                                   _notificationRepositoryMock.Object);
+        }
+        [Fact]
+        public async Task CountAsync_NotificationsExist_ShouldReturnCorrectCount()
+        {
+            // Arrange
+            var userId = "testUserId";
+            var unreadNotifications = new List<Notification>
+            {
+                new Notification { UserId = userId, IsRead = false },
+                new Notification { UserId = userId, IsRead = false },
+            };
+
+            _notificationRepositoryMock.Setup(x => x.GetByFilterAsync(It.IsAny<Expression<Func<Notification, bool>>>()))
+                                      .ReturnsAsync(unreadNotifications);
+
+            // Act
+            var actual = await _sut.CountAsync(userId);
+
+            // Assert
+            Assert.Equal(unreadNotifications.Count, actual);
+            _notificationRepositoryMock.Verify(x => x.GetByFilterAsync(It.IsAny<Expression<Func<Notification, bool>>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CountAsync_NoNotifications_ShouldReturnZero()
+        {
+            // Arrange
+            var userId = "testUserId";
+            var emptyList = new List<Notification>();
+
+            _notificationRepositoryMock.Setup(x => x.GetByFilterAsync(It.IsAny<Expression<Func<Notification, bool>>>()))
+                                      .ReturnsAsync(emptyList);
+
+            // Act
+            var actual = await _sut.CountAsync(userId);
+
+            // Assert
+            Assert.Equal(0, actual);
+            _notificationRepositoryMock.Verify(x => x.GetByFilterAsync(It.IsAny<Expression<Func<Notification, bool>>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateAsync_CreatorExists_ShouldAddNotificationWithCreatorName()
+        {
+            // Arrange
+            var dinnerInvitation = new DinnerInvitation { CreatorId = "creatorId" };
+            var userId = "testUserId";
+            var creator = new ItTakesAVillageUser { Id = dinnerInvitation.CreatorId, FirstName = "John", LastName = "Doe" };
+
+            _userRepositoryMock.Setup(x => x.GetAsync(dinnerInvitation.CreatorId))
+                             .ReturnsAsync(creator);
+
+            _notificationRepositoryMock.Setup(x => x.AddAsync(It.IsAny<Notification>()))
+                                      .Returns(Task.CompletedTask);
+
+            // Act
+            await _sut.CreateAsync(dinnerInvitation, userId);
+
+            // Assert
+            _notificationRepositoryMock.Verify(x => x.AddAsync(It.IsAny<Notification>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateAsync_CreatorDoesNotExist_ShouldAddNotificationWithUnknownCreator()
+        {
+            // Arrange
+            var dinnerInvitation = new DinnerInvitation { CreatorId = "nonExistentId" };
+            var userId = "testUserId";
+
+            _userRepositoryMock.Setup(x => x.GetAsync(dinnerInvitation.CreatorId))
+                             .ReturnsAsync(null as ItTakesAVillageUser); 
+
+            _notificationRepositoryMock.Setup(x => x.AddAsync(It.IsAny<Notification>()))
+                                      .Returns(Task.CompletedTask);
+            // Act
+            await _sut.CreateAsync(dinnerInvitation, userId);
+
+            // Assert
+            _notificationRepositoryMock.Verify(x => x.AddAsync(It.IsAny<Notification>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateIsReadAsync_NotificationExists_ShouldUpdateAndCallUpdateAsync()
+        {
+            // Arrange
+            var notificationId = 1;
+            var existingNotification = new Notification { Id = notificationId, IsRead = false };
+
+            _notificationRepositoryMock.Setup(x => x.GetAsync(notificationId))
+                                      .ReturnsAsync(existingNotification);
+
+            // Act
+            await _sut.UpdateIsReadAsync(notificationId);
+
+            // Assert
+            Assert.True(existingNotification.IsRead);
+            _notificationRepositoryMock.Verify(x => x.UpdateAsync(existingNotification), Times.Once);
+        }
+
+        [Fact]
+        public async Task UpdateIsReadAsync_NotificationDoesNotExist_ShouldNotCallUpdateAsync()
+        {
+            // Arrange
+            var nonExistentNotificationId = 999;
+
+            _notificationRepositoryMock.Setup(x => x.GetAsync(nonExistentNotificationId))
+                                      .ReturnsAsync(null as Notification);
+
+            // Act
+            await _sut.UpdateIsReadAsync(nonExistentNotificationId);
+
+            // Assert
+            _notificationRepositoryMock.Verify(x => x.UpdateAsync(It.IsAny<Notification>()), Times.Never);
+        }
+    }
+}

--- a/ItTakesAVillage/Pages/DinnerInvitation.cshtml.cs
+++ b/ItTakesAVillage/Pages/DinnerInvitation.cshtml.cs
@@ -51,7 +51,6 @@ namespace ItTakesAVillage.Pages
                     bool success = await _dinnerInvitationService.Create(NewInvitation);                    
                     if(success)
                         await _notificationService.NotifyGroupAsync(NewInvitation);                                       
-                    //TODO Om ovan lyckas, ska en notification skickas till alla i gruppen
                 }
             }
             return RedirectToPage("/DinnerInvitation");

--- a/ItTakesAVillage/Services/DinnerInvitationService.cs
+++ b/ItTakesAVillage/Services/DinnerInvitationService.cs
@@ -19,15 +19,11 @@ namespace ItTakesAVillage.Services
         }
         public async Task<bool> Create(DinnerInvitation invitation)
         {
-            try
-            {
-                await _dinnerInvitationRepository.AddAsync(invitation);
-                return true;
-            }
-            catch
-            {
+            if (invitation.DateTime.Date < DateTime.Now)
                 return false;
-            }
+
+            await _dinnerInvitationRepository.AddAsync(invitation);
+            return true;
         }
     }
 }

--- a/ItTakesAVillage/Services/NotificationService.cs
+++ b/ItTakesAVillage/Services/NotificationService.cs
@@ -54,7 +54,7 @@ namespace ItTakesAVillage.Services
                 await _notificationRepository.UpdateAsync(existingNotification);
             }
         }
-        private async Task CreateAsync(DinnerInvitation dinnerInvitation, string userId)
+        public async Task CreateAsync(DinnerInvitation dinnerInvitation, string userId)
         {
             var creator = await _userRepository.GetAsync(dinnerInvitation.CreatorId);
             var newNotification = new Notification


### PR DESCRIPTION
## Checklist
- [x] Closes: unit tests for invitationservice and notificationservice
- [x] Communication: I've discussed this with core contributors lready. If work hasn't been agreed, this work might be rejected 
- [x] Tests: Added/updated and all pass
- [ ] Dev docs: Added/updated

## Description
This PR adds unit tests for invitationservice and notificationservice and moves the Mock objects into the constructor in each testclass to keep the tests more DRY.